### PR TITLE
Workaround for #28

### DIFF
--- a/roles_files/nodejs/defaults/main.yml
+++ b/roles_files/nodejs/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 nodejs_enabled: yes                       # The role is enabled
-nodejs_version: 4.2.3
+nodejs_version: 4.4.0
 nodejs_install: pkg                       # Install nodejs from packages, sources or binary
                                           # (pkg|src|bin)
 


### PR DESCRIPTION
Installing nodejs manually provides the 4.4.0 version number. Setting the version to 4.4.0 seems to work, for now
