### PR TITLE
Install python2 before running provisioning

### DIFF
--- a/templates/ansible/playbook.yml
+++ b/templates/ansible/playbook.yml
@@ -1,5 +1,12 @@
 ---
 
+- hosts: all
+  gather_facts: False
+
+  tasks:
+  - name: install python 2
+    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qy python-minimal)"
+
 - name: Provisioning {{ project_name }}
   hosts: {{ hosts }}
   become: {{ sudo }}


### PR DESCRIPTION
Running the provisioning fails if python2 is not installed on the machine (which is now not the case as python3 is installed)