### PR TITLE
[Fix] Update nodejs_install_npm_user variable

### DIFF
--- a/roles_files/any-nodejs/tasks/main.yml
+++ b/roles_files/any-nodejs/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Define nodejs_install_npm_user
   set_fact:
-    nodejs_install_npm_user: "{{ ansible_user }}"
+    nodejs_install_npm_user: "{{ ansible_ssh_user }}"
   when: nodejs_install_npm_user is not defined
 
 - name: Create npm global directory


### PR DESCRIPTION
Fix on error `One or more undefined variables: 'ansible_user' is undefined` while provisioning.